### PR TITLE
Enabled backface culling, refactored mesh code

### DIFF
--- a/include/mesh.h
+++ b/include/mesh.h
@@ -1,13 +1,13 @@
 #ifndef PRGL_MESH_H
 #define PRGL_MESH_H
 
-#include "cglm/types.h"
-
 /**
  * @brief Defines the geometry of a 3D object.
  *
  * One mesh can be re-used to render many of the same object.
  * Any IDs which are optional should be set to 0 if unused.
+ *
+ * The texture_id must be set manually after init to a loaded texture.
  */
 struct PRGLMesh
 {
@@ -27,23 +27,17 @@ struct PRGLMesh
 };
 
 /**
- * @brief Creates a triangle mesh with the given vertex positions.
- *
- * @param[in] vertices
+ * @brief Creates a triangle mesh.
  */
-struct PRGLMesh *prgl_create_triangle(mat3 vertices);
+struct PRGLMesh *prgl_create_triangle(void);
 
 /**
- * Creates a quad mesh. For 3D the normals assume XY orientation.
- * Make sure to attach a texture to the returned mesh struct after creating it.
- *
- * @param[in] vertices
+ * @brief Creates a quad mesh.
  */
-struct PRGLMesh *prgl_create_quad(mat4 vertices);
+struct PRGLMesh *prgl_create_quad(void);
 
 /**
  * @brief Creates a cube mesh.
- * Make sure to attach a texture to the returned mesh struct after creating it.
  */
 struct PRGLMesh *prgl_create_cube(void);
 

--- a/src/render.c
+++ b/src/render.c
@@ -27,10 +27,8 @@ void prgl_render_game_object_3d(struct PRGLGameObject *const game_obj)
 {
     glBindVertexArray(game_obj->mesh->vao);
 
-    if (game_obj->mesh->texture_id != 0)
-    {
-        glBindTexture(GL_TEXTURE_2D, game_obj->mesh->texture_id);
-    }
+    // Don't skip this if ID is zero'd, otherwise it uses the last bound texture
+    glBindTexture(GL_TEXTURE_2D, game_obj->mesh->texture_id);
 
     // Transform the mesh to the render position.
     mat4 model;
@@ -60,10 +58,7 @@ void prgl_render_game_object_2d(struct PRGLGameObject *const game_obj)
 {
     glBindVertexArray(game_obj->mesh->vao);
 
-    if (game_obj->mesh->texture_id != 0)
-    {
-        glBindTexture(GL_TEXTURE_2D, game_obj->mesh->texture_id);
-    }
+    glBindTexture(GL_TEXTURE_2D, game_obj->mesh->texture_id);
 
     // Transform the mesh to the render position.
     mat4 trans;
@@ -71,12 +66,15 @@ void prgl_render_game_object_2d(struct PRGLGameObject *const game_obj)
     vec2 scale = {game_obj->scale[0], game_obj->scale[1]};
 
     glm_mat4_identity(trans);
+
+    // Same meshes are used for 2D/3D, and they are center aligned unit meshes.
+    // For 2D we want top left for position, so we need to offset.
+    vec2 center_offset = {scale[0] / 2.0f, scale[1] / 2.0f};
     glm_translate(trans, (vec3){position[0], position[1], 0.0f});
+    glm_translate(trans, (vec3){center_offset[0], center_offset[1], 0.0f});
 
     // Perform the rotation about the center of the game object
-    glm_translate(trans, (vec3){0.5f * scale[0], 0.5f * scale[1], 0.0f});
     glm_quat_rotate(trans, game_obj->orientation, trans);
-    glm_translate(trans, (vec3){-0.5f * scale[0], -0.5f * scale[1], 0.0f});
 
     // Negate y-axis scale, cglm quats expects 3D right hand coordinate with +y
     // up, but our 2D orthogonal projection has 0,0 at top left so -y is up

--- a/src/screen.c
+++ b/src/screen.c
@@ -61,6 +61,8 @@ void prgl_create_window(const char *const name)
     }
 
     glEnable(GL_DEPTH_TEST);
+    glEnable(GL_CULL_FACE);
+    glCullFace(GL_BACK);
 
     prgl_screen_data = (struct PRGLScreen
     ){.window = window,

--- a/src/transform.c
+++ b/src/transform.c
@@ -15,7 +15,7 @@ void prgl_create_model_matrix(mat4 model, struct PRGLGameObject *const game_obj)
 void prgl_create_normal_matrix(mat3 normal_matrix, mat4 model)
 {
     mat4 normal_mat4;
-    glm_mat4_copy(model, normal_mat4);
-    glm_inv_tr(normal_mat4);
+    glm_mat4_inv(model, normal_mat4);
+    glm_mat4_transpose(normal_mat4);
     glm_mat4_pick3(normal_mat4, normal_matrix);
 }


### PR DESCRIPTION
- Backface culling enabled.
- Reordered all mesh vertices to be CCW so they have front faces facing outward.
- Updated all mesh creation code to create unit meshes.
- Updated 2D rendering code to support using the same unit meshes since they now have center origin, 2D rendering will now translate to have top left and then render.

Closes #30